### PR TITLE
Fix uploading through the reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ server {
 
     access_log            /var/log/nginx/myserver.access.log;
 
+    client_max_body_size 256M; # Make the number the same as 'max-file-size' in fileshelter.conf
     proxy_request_buffering off;
     proxy_buffering off;
     proxy_buffer_size 4k;


### PR DESCRIPTION
Without `client_max_body_size`, uploads above 1MB will fail. This change increases the file upload size limit for nginx, fixing the issue.

Edit: I'm dumb, this is meant to go in the fileshelter repo