### PR TITLE
Fixed several compilation errors

### DIFF
--- a/src/libs/utils/impl/Random.cpp
+++ b/src/libs/utils/impl/Random.cpp
@@ -29,7 +29,7 @@ RandGenerator& getRandGenerator()
 	return randGenerator;
 }
 
-RandGenerator createSeededGenerator(std::size_t seed)
+RandGenerator createSeededGenerator(uint_fast32_t seed)
 {
 	return RandGenerator {seed};
 }

--- a/src/libs/utils/include/utils/Random.hpp
+++ b/src/libs/utils/include/utils/Random.hpp
@@ -27,7 +27,7 @@ namespace Random {
 using RandGenerator = std::mt19937;
 RandGenerator& getRandGenerator();
 
-RandGenerator createSeededGenerator(std::size_t seed);
+RandGenerator createSeededGenerator(uint_fast32_t seed);
 
 template <typename T>
 T

--- a/src/lms/ui/explore/ArtistsView.hpp
+++ b/src/lms/ui/explore/ArtistsView.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include <Wt/WComboBox.h>

--- a/src/lms/ui/explore/ReleasesView.hpp
+++ b/src/lms/ui/explore/ReleasesView.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <optional>
+#include <unordered_map>
 
 #include <Wt/WContainerWidget.h>
 #include <Wt/WTemplate.h>

--- a/src/lms/ui/explore/TracksView.hpp
+++ b/src/lms/ui/explore/TracksView.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <optional>
+#include <unordered_map>
 
 #include <Wt/WContainerWidget.h>
 #include <Wt/WTemplate.h>

--- a/src/lms/ui/resource/DownloadResource.cpp
+++ b/src/lms/ui/resource/DownloadResource.cpp
@@ -19,6 +19,7 @@
 
 #include "DownloadResource.hpp"
 
+#include <array>
 #include <iostream>
 #include <iomanip>
 

--- a/src/tools/zipper/LmsZipper.cpp
+++ b/src/tools/zipper/LmsZipper.cpp
@@ -18,6 +18,8 @@
  */
 
 #include <unistd.h>
+
+#include <array>
 #include <fstream>
 #include <iostream>
 


### PR DESCRIPTION
Several compile issues arose when compiling lsm on FreeBSD 12.1 using clang 8.0.1. The issues and their resolution are listed below.

```
/root/lmsbram/src/libs/utils/impl/Random.cpp:34:24: error: non-constant-expression cannot be narrowed from type 'std::size_t' (aka 'unsigned long') to 'std::__1::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11,
      4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253>::result_type' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        return RandGenerator {seed};
                              ^~~~
/root/lmsbram/src/libs/utils/impl/Random.cpp:34:24: note: insert an explicit cast to silence this issue
        return RandGenerator {seed};
                              ^~~~
                              static_cast<result_type>( )
```
Resolution: Changed `std::size_t` to `uint_fast32_t`

```
/root/lmsbram/src/lms/ui/explore/ArtistsView.hpp:67:22: error: no template named 'unordered_map' in namespace 'std'
                static inline std::unordered_map<Mode, std::optional<std::size_t>> maxItemsPerMode
                              ~~~~~^
```                              
Resolution: Added `#include <unordered_map>`, same issue occured for the files ReleasesView.hpp and TracksView.hpp

```
/root/lmsbram/src/lms/ui/resource/DownloadResource.cpp:68:37: error: implicit instantiation of undefined template 'std::__1::array<std::byte, 32768>'
                std::array<std::byte, bufferSize> buffer;
                                                  ^
/usr/include/c++/v1/__tuple:223:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
```
Resolution: Added `#include <array>`, same issue occured for LmsZipper.cpp
