### PR TITLE
Exclude gtests when cross-compiling

### DIFF
--- a/src/libs/database/test/CMakeLists.txt
+++ b/src/libs/database/test/CMakeLists.txt
@@ -12,5 +12,7 @@ target_link_libraries(test-database PRIVATE
 	GTest::GTest
 	)
 
-gtest_discover_tests(test-database)
+if (NOT CMAKE_CROSSCOMPILING)
+	gtest_discover_tests(test-database)
+endif()
 

--- a/src/libs/metadata/test/CMakeLists.txt
+++ b/src/libs/metadata/test/CMakeLists.txt
@@ -14,5 +14,7 @@ target_link_libraries(test-metadata PRIVATE
 	GTest::GTest
 	)
 
-gtest_discover_tests(test-metadata)
+if (NOT CMAKE_CROSSCOMPILING)
+	gtest_discover_tests(test-metadata)
+endif()
 

--- a/src/libs/som/test/CMakeLists.txt
+++ b/src/libs/som/test/CMakeLists.txt
@@ -9,5 +9,7 @@ target_link_libraries(test-som PRIVATE
 	GTest::GTest
 	)
 
-gtest_discover_tests(test-som)
+if (NOT CMAKE_CROSSCOMPILING)
+	gtest_discover_tests(test-som)
+endif()
 

--- a/src/libs/utils/test/CMakeLists.txt
+++ b/src/libs/utils/test/CMakeLists.txt
@@ -12,5 +12,7 @@ target_link_libraries(test-utils PRIVATE
 	GTest::GTest
 	)
 
-gtest_discover_tests(test-utils)
+if (NOT CMAKE_CROSSCOMPILING)
+	gtest_discover_tests(test-utils)
+endif()
 


### PR DESCRIPTION
Tests cannot be executed when cross-compiling

Requesting pull for the develop branch as said in https://github.com/epoupon/lms/pull/173#issuecomment-930368938