### PR TITLE
Added missing <unordered_map> include

### DIFF
--- a/src/libs/subsonic/impl/SubsonicResource.hpp
+++ b/src/libs/subsonic/impl/SubsonicResource.hpp
@@ -19,6 +19,8 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
+
 #include <Wt/WResource.h>
 #include <Wt/Http/Response.h>
 


### PR DESCRIPTION
This fixes the compilation on FreeBSD. The error message is provided below.
Great work by the way! 

`In file included from /wrkdirs/usr/ports/www/lms/work/lms-3.27.0/src/libs/subsonic/impl/SubsonicResource.cpp:20:
/wrkdirs/usr/ports/www/lms/work/lms-3.27.0/src/libs/subsonic/impl/SubsonicResource.hpp:51:15: error: no template named 'unordered_map' in namespace 'std'
                        const std::unordered_map<std::string, ProtocolVersion> _serverProtocolVersionsByClient;`