### PR TITLE
Add mission include for std::optional

### DIFF
--- a/src/libs/services/auth/include/services/auth/IPasswordService.hpp
+++ b/src/libs/services/auth/include/services/auth/IPasswordService.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string_view>
+#include <optional>
 
 #include <boost/asio/ip/address.hpp>
 #include <Wt/WDateTime.h>


### PR DESCRIPTION
Hi,

To build on Arch Linux I had to add a missing include in IPasswordService.hpp.
I have built and ran the all test successfully in a Debian:buster docker image.