### PR TITLE
fix: av_guess_format interface has changed with 5.0

### DIFF
--- a/src/libs/av/impl/AudioFile.cpp
+++ b/src/libs/av/impl/AudioFile.cpp
@@ -241,7 +241,7 @@ AudioFile::visitAttachedPictures(std::function<void(const Picture&)> func) const
 std::optional<AudioFileFormat>
 guessMediaFileFormat(const std::filesystem::path& file)
 {
-	AVOutputFormat* format {av_guess_format(NULL,file.string().c_str(),NULL)};
+	const AVOutputFormat* format {av_guess_format(NULL,file.string().c_str(),NULL)};
 	if (!format || !format->name)
 		return {};
 

--- a/src/libs/services/auth/include/services/auth/IPasswordService.hpp
+++ b/src/libs/services/auth/include/services/auth/IPasswordService.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string_view>
+#include <optional>
 
 #include <boost/asio/ip/address.hpp>
 #include <Wt/WDateTime.h>


### PR DESCRIPTION
FFMPEG API has changed in 5.x, so av_guess_format return a const AVOutputFormat.
Build and tested on Arch Linux with FFMPEG 5 and Debian Buster with FFMPEG4.