### PR TITLE
Update document title when loading a new track

### DIFF
--- a/docroot/js/mediaplayer.js
+++ b/docroot/js/mediaplayer.js
@@ -359,6 +359,27 @@ LMS.mediaplayer = function () {
 				artwork: params.artwork,
 			});
 		}
+
+		var newTitle = "";
+
+		if (params.title) {
+			newTitle += params.title;
+		}
+		else {
+			newTitle += "<unk>";
+		}
+
+		newTitle += " - ";
+
+		if (params.release) {
+			newTitle += params.release;
+		}
+		else {
+			newTitle += "<unk>";
+		}
+
+		newTitle += " | LMS";
+		document.title = newTitle;
 	}
 
 	var stop = function() {


### PR DESCRIPTION
This updates the title to something more informative than "LMS" by including title and album in the title. The media session API should be mostly sufficient on most platforms, but does not work reliably (or at all) on my Edge browser, so I propose this change.

That `<unk>` is just a placeholder, I still need to figure out how to do i18n from JavaScript.