### PR TITLE
Build Essentia in release

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -127,7 +127,7 @@ RUN \
 	PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig CXXFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,--rpath-link=${PREFIX}/lib" ./waf configure \
 		--mode=release \
 		--lightweight=libav,libsamplerate,taglib,yaml \
-		--ignore-algos=LPC,Spline,CubicSpline \
+		--ignore-algos=LPC,Spline,CubicSpline,NoveltyCurve,NoveltyCurveFixedBpmEstimator,SuperFluxNovelty,SuperFluxPeaks,VectorRealAccumulator,VectorRealToTensor,TensorToPool,TensorNormalize,NSGConstantQStreaming,NSGIConstantQ,PredominantPitchMelodia,PitchMelodia,MultiPitchMelodia,PitchContoursMonoMelody,PitchContourSegmentation,TonicIndianArtMusic,AudioWriter,MonoWriter,AudioOnsetsMarker,ChromaCrossSimilarity,CoverSongSimilarity,CrossSimilarityMatrix,FadeDetection,HarmonicMask,HarmonicModelAnal,HpsModelAnal,HprModelAnal,FreesoundExtractor \
 		--fft=KISS \
 		--with-example streaming_extractor_music \
 		--prefix=${PREFIX} && \

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -33,7 +33,6 @@ ARG	BUILD_PACKAGES=" \
 	gtest-dev \
 	eigen-dev \
 	yaml-dev \
-	fftw-dev \
 	python3"
 
 RUN	apk add --no-cache --update ${BUILD_PACKAGES}
@@ -76,7 +75,7 @@ RUN \
 	--enable-protocol=file,pipe \
 	--enable-filter=aresample \
 	--extra-libs=-ldl && \
-	make && \
+	make -j $(nproc) && \
 	make install && \
 	make distclean
 
@@ -90,7 +89,7 @@ RUN \
 RUN \
 	DIR=/tmp/wt && mkdir -p ${DIR} && cd ${DIR} && \
 	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -DBUILD_EXAMPLES=OFF -DENABLE_LIBWTTEST=OFF -DCONNECTOR_FCGI=OFF && \
-	make && \
+	make -j $(nproc) && \
 	make install
 
 # STB
@@ -112,7 +111,7 @@ RUN \
 RUN \
 	DIR=/tmp/libsamplerate/build && mkdir -p ${DIR} && cd ${DIR} && \
 	cmake /tmp/libsamplerate -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_PREFIX_PATH=${PREFIX} && \
-	make && \
+	make -j $(nproc) && \
 	make install
 
 # Essentia
@@ -125,8 +124,14 @@ RUN \
 RUN \
 	DIR=/tmp/essentia && mkdir -p ${DIR} && cd ${DIR} && \
 	chmod +x ./waf && \
-	PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig CXXFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,--rpath-link=${PREFIX}/lib" ./waf configure --mode=release --with-example streaming_extractor_music --prefix=${PREFIX} && \
-	PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig CXXFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,--rpath-link=${PREFIX}/lib" ./waf && \
+	PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig CXXFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,--rpath-link=${PREFIX}/lib" ./waf configure \
+		--mode=release \
+		--lightweight=libav,libsamplerate,taglib,yaml \
+		--ignore-algos=LPC,Spline,CubicSpline \
+		--fft=KISS \
+		--with-example streaming_extractor_music \
+		--prefix=${PREFIX} && \
+	PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig CXXFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,--rpath-link=${PREFIX}/lib" ./waf -j $(nproc) && \
 	./waf install
 
 # LMS
@@ -134,7 +139,7 @@ COPY . /tmp/lms/
 RUN \
 	DIR=/tmp/lms/build && mkdir -p ${DIR} && cd ${DIR} && \
 	PKG_CONFIG_PATH=/tmp/install/lib/pkgconfig CXXFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,--rpath-link=${PREFIX}/lib" cmake /tmp/lms/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_PREFIX_PATH=${PREFIX} && \
-	LD_LIBRARY_PATH=${PREFIX}/lib VERBOSE=1 make && \
+	LD_LIBRARY_PATH=${PREFIX}/lib VERBOSE=1 make -j $(nproc) && \
 	LD_LIBRARY_PATH=${PREFIX}/lib make test && \
 	make install && \
 	mkdir -p ${PREFIX}/etc/ && \
@@ -183,8 +188,7 @@ ARG	RUNTIME_PACKAGES=" \
 	libconfig++ \
 	taglib \
 	eigen \
-	yaml \
-	fftw"
+	yaml"
 
 ARG	LMS_USER=lms
 ARG	LMS_GROUP=lms

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -30,7 +30,11 @@ ARG	BUILD_PACKAGES=" \
 	boost-dev \
 	libconfig-dev \
 	taglib-dev \
-	gtest-dev"
+	gtest-dev \
+	eigen-dev \
+	yaml-dev \
+	fftw-dev \
+	python3"
 
 RUN	apk add --no-cache --update ${BUILD_PACKAGES}
 
@@ -98,6 +102,33 @@ RUN \
 	mkdir -p ${PREFIX}/include/stb && \
 	cp ./*.h ${PREFIX}/include/stb
 
+# libsamplerate
+ARG LIBSAMPLERATE_VERSION=0.2.2
+RUN \
+	DIR=/tmp/libsamplerate && mkdir -p ${DIR} && cd ${DIR} && \
+	curl -sLO https://github.com/libsndfile/libsamplerate/archive/${LIBSAMPLERATE_VERSION}.tar.gz && \
+	tar -x --strip-components=1 -f ${LIBSAMPLERATE_VERSION}.tar.gz
+
+RUN \
+	DIR=/tmp/libsamplerate/build && mkdir -p ${DIR} && cd ${DIR} && \
+	cmake /tmp/libsamplerate -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_PREFIX_PATH=${PREFIX} && \
+	make && \
+	make install
+
+# Essentia
+ARG ESSENTIA_VERSION=e422eb7681a9063d2681c3540d91add1119f21c0
+RUN \
+	DIR=/tmp/essentia && mkdir -p ${DIR} && cd ${DIR} && \
+	curl -sLO https://github.com/MTG/essentia/archive/${ESSENTIA_VERSION}.tar.gz && \
+	tar -x --strip-components=1 -f ${ESSENTIA_VERSION}.tar.gz
+
+RUN \
+	DIR=/tmp/essentia && mkdir -p ${DIR} && cd ${DIR} && \
+	chmod +x ./waf && \
+	PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig CXXFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,--rpath-link=${PREFIX}/lib" ./waf configure --mode=release --with-example streaming_extractor_music --prefix=${PREFIX} && \
+	PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig CXXFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,--rpath-link=${PREFIX}/lib" ./waf && \
+	./waf install
+
 # LMS
 COPY . /tmp/lms/
 RUN \
@@ -112,7 +143,7 @@ RUN \
 # Now copy all the stuff installed in a new folder (/tmp/fakeroot/)
 RUN \
 	mkdir -p /tmp/fakeroot/bin && \
-	for bin in ${PREFIX}/bin/ffmpeg ${PREFIX}/bin/lms*; \
+	for bin in ${PREFIX}/bin/ffmpeg ${PREFIX}/bin/essentia_streaming_extractor_music ${PREFIX}/bin/lms*; \
 	do \
 		strip --strip-all $bin && \
 		cp $bin /tmp/fakeroot/bin/; \
@@ -150,7 +181,10 @@ ARG	RUNTIME_PACKAGES=" \
 	boost-system \
 	boost-thread \
 	libconfig++ \
-	taglib"
+	taglib \
+	eigen \
+	yaml \
+	fftw"
 
 ARG	LMS_USER=lms
 ARG	LMS_GROUP=lms


### PR DESCRIPTION
Related to #221.

This builds a working `essentia_streaming_extractor_music` binary in `/usr/bin` that can be used to extract music features. It is not a static build and uses the ffmpeg library that are built in the same process.

Along with other dependencies, this change makes the final image much larger at 50 MiB on my local system.

libsamplerate is built manually since Alpine does not package it, but it is present in Debian and Arch. Apart from this, you should be able to copy my changes to other Dockerfile and call it a day (this will make CI slower, so proceed with caution).

Essentia can become problematic when Debian moves to ffmpeg 5.x (the current stable is fine, but testing and sid are already on 5.x).

BTW, why aren't you doing `make -j$(nproc)` when building these libraries?