### PR TITLE
Support tags with spaces in their label, e.g. "ALBUM RATING"

### DIFF
--- a/src/lms/ui/admin/DatabaseSettingsView.cpp
+++ b/src/lms/ui/admin/DatabaseSettingsView.cpp
@@ -114,7 +114,7 @@ class DatabaseSettingsModel : public Wt::WFormModel
 			{
 				std::vector<std::string> names;
 				std::transform(clusterTypes.begin(), clusterTypes.end(), std::back_inserter(names),  [](auto clusterType) { return clusterType->getName(); });
-				setValue(ClustersField, StringUtils::joinStrings(names, " "));
+				setValue(ClustersField, StringUtils::joinStrings(names, ";"));
 			}
 		}
 
@@ -138,7 +138,7 @@ class DatabaseSettingsModel : public Wt::WFormModel
 			if (similarityEngineTypeRow)
 				scanSettings.modify()->setSimilarityEngineType(_similarityEngineTypeModel->getValue(*similarityEngineTypeRow));
 
-			auto clusterTypes {StringUtils::splitStringCopy(valueText(ClustersField).toUTF8(), " ")};
+			auto clusterTypes {StringUtils::splitStringCopy(valueText(ClustersField).toUTF8(), ";")};
 			scanSettings.modify()->setClusterTypes(LmsApp->getDbSession(), std::set<std::string>(clusterTypes.begin(), clusterTypes.end()));
 		}
 


### PR DESCRIPTION
Following the issue reported at #353, I had a quick look at the code and I believe I found a simple way to support tags with spaces in their label, by replacing the " " separator with a ";". As far as I know, no tag labels should contain a ";". The list of tags would then look like this:
![image](https://github.com/epoupon/lms/assets/12874678/0cff6acf-0026-490a-a535-805b681e6337)

Please note that I haven't tested this, as I wanted to get a first opinion on how reasonable this approach is for you.