### PR TITLE
Sort albums using sort_name column first

### DIFF
--- a/src/libs/database/impl/Release.cpp
+++ b/src/libs/database/impl/Release.cpp
@@ -167,10 +167,10 @@ namespace lms::db
             case ReleaseSortMethod::None:
                 break;
             case ReleaseSortMethod::Name:
-                query.orderBy("r.name COLLATE NOCASE");
+                query.orderBy("COALESCE(r.sort_name, r.name) COLLATE NOCASE");
                 break;
             case ReleaseSortMethod::ArtistNameThenName:
-                query.orderBy("a.name COLLATE NOCASE, r.name COLLATE NOCASE");
+                query.orderBy("COALESCE(a.sort_name, a.name) COLLATE NOCASE, COALESCE(r.sort_name, r.name) COLLATE NOCASE");
                 break;
             case ReleaseSortMethod::Random:
                 query.orderBy("RANDOM()");
@@ -179,13 +179,13 @@ namespace lms::db
                 query.orderBy("t.file_last_write DESC");
                 break;
             case ReleaseSortMethod::Date:
-                query.orderBy("COALESCE(t.date, CAST(t.year AS TEXT)), r.name COLLATE NOCASE");
+                query.orderBy("COALESCE(t.date, CAST(t.year AS TEXT)), COALESCE(r.sort_name, r.name) COLLATE NOCASE");
                 break;
             case ReleaseSortMethod::OriginalDate:
-                query.orderBy("COALESCE(original_date, CAST(original_year AS TEXT), date, CAST(year AS TEXT)), r.name COLLATE NOCASE");
+                query.orderBy("COALESCE(original_date, CAST(original_year AS TEXT), date, CAST(year AS TEXT)), COALESCE(r.sort_name, r.name) COLLATE NOCASE");
                 break;
             case ReleaseSortMethod::OriginalDateDesc:
-                query.orderBy("COALESCE(original_date, CAST(original_year AS TEXT), date, CAST(year AS TEXT)) DESC, r.name COLLATE NOCASE");
+                query.orderBy("COALESCE(original_date, CAST(original_year AS TEXT), date, CAST(year AS TEXT)) DESC, COALESCE(r.sort_name, r.name) COLLATE NOCASE");
                 break;
             case ReleaseSortMethod::StarredDateDesc:
                 assert(params.starringUser.isValid());


### PR DESCRIPTION
WORK IN (VERY SLOW) PROGRESS

---

This PR improves how the albums are sorted in the `Albums / All` view: if a `sort_name` exists then it will be used first. E.g. the `ALBUM` _A Fallen Temple_ will appear under the letter _F_ (because the `ALBUMSORT` is _Fallen Temple, A_).

Before:

![image](https://github.com/epoupon/lms/assets/2331798/924aa2cf-bd49-4403-8479-5cc22951dcff)

After:

![image](https://github.com/epoupon/lms/assets/2331798/51e2db43-130b-4041-bf8d-70428b58ee8e) 