### PR TITLE
UpperCaseValidator: add missing header

### DIFF
--- a/src/lms/ui/common/UppercaseValidator.cpp
+++ b/src/lms/ui/common/UppercaseValidator.cpp
@@ -19,6 +19,7 @@
 
 #include "UppercaseValidator.hpp"
 
+#include <algorithm>
 #include <string>
 #include <string_view>
 


### PR DESCRIPTION
While compiling with the experimental GCC 14 LMS fails to build with the next error 

> /var/tmp/portage/media-sound/lms-3.53.0/work/lms-3.53.0/src/lms/ui/common/UppercaseValidator.cpp: In member function ‘virtual Wt::WValidator::Result lms::ui::UppercaseValidator::validate(const Wt::WString&) const’:
> /var/tmp/portage/media-sound/lms-3.53.0/work/lms-3.53.0/src/lms/ui/common/UppercaseValidator.cpp:40:32: error: ‘all_of’ is not a member of ‘std’
>    40 |         const bool valid{ std::all_of(std::cbegin(str), std::cend(str), [&](char c) { return !std::isalpha(c) || std::isupper(c);}) };
>       |                                ^~~~~~

The issue seems a missing header file. This patch should fix it 