### PR TITLE
Inline TrackArtistLinks in Album page

### DIFF
--- a/approot/release.xml
+++ b/approot/release.xml
@@ -123,6 +123,9 @@
 			</div>
 		</div>
 	</div>
+	${<if-has-remixers>}<div class="ms-5 pb-2 px-2 text-small">
+		Remixer — ${remixers class="d-inline d-md-inline"}
+	</div>${</if-has-remixers>}
 </message>
 
 <message id="Lms.Explore.Release.template.release-info">

--- a/approot/release.xml
+++ b/approot/release.xml
@@ -123,9 +123,9 @@
 			</div>
 		</div>
 	</div>
-	${<if-has-remixers>}<div class="ms-5 pb-2 px-2 text-small">
-		Remixer — ${remixers class="d-inline d-md-inline"}
-	</div>${</if-has-remixers>}
+	${<if-has-artist-links>}
+		${artist-links}
+	${</if-has-artist-links>}
 </message>
 
 <message id="Lms.Explore.Release.template.release-info">

--- a/src/lms/ui/explore/ReleaseView.cpp
+++ b/src/lms/ui/explore/ReleaseView.cpp
@@ -437,6 +437,13 @@ namespace lms::ui
                 entry->bindWidget("artists-md", utils::createArtistDisplayNameWithAnchors(track->getArtistDisplayName(), artists));
             }
 
+            const auto remixers{ track->getArtistIds({ TrackArtistLinkType::Remixer }) };
+            if (!remixers.empty())
+            {
+                entry->setCondition("if-has-remixers", true);
+                entry->bindWidget("remixers", utils::createArtistDisplayNameWithAnchors(track->getArtistDisplayName(), remixers));
+            }
+
             auto trackNumber{ track->getTrackNumber() };
             if (trackNumber)
             {


### PR DESCRIPTION
Implement #626
First time using Wt, feel free to correct me, similarly feel free to correct my code styling.

Current implementation works for all `TrackArtistLinkType`. It is currently hardcoded to display them all. This PR is set as draft as I will be implementing a config in the user's settings to either show only remixers (my initial goal), all relationships, or nothing.

![image](https://github.com/user-attachments/assets/5ec90f65-200a-4f97-8f70-edca40818244)

![image](https://github.com/user-attachments/assets/65e01487-8aba-425a-9829-548451a322e1)
