### PR TITLE
FileResourceHandler: Open file once on init, more error handling

### DIFF
--- a/src/libs/core/impl/FileResourceHandler.hpp
+++ b/src/libs/core/impl/FileResourceHandler.hpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <string>
 #include <string_view>
+#include <fstream>
 
 #include "core/IResourceHandler.hpp"
 
@@ -38,9 +39,10 @@ namespace lms::core
 
         static constexpr std::size_t _chunkSize{ 262'144 };
 
-        std::filesystem::path _path;
         std::string _mimeType;
         ::uint64_t _beyondLastByte{};
         ::uint64_t _offset{};
+        ::uint64_t _fileSize{};
+        std::ifstream _ifs;
     };
 } // namespace lms::core


### PR DESCRIPTION
Split off from the disk caching draft PR.

Keeping the file open allows better prefetching/caching on both the application layer (ifstream) and OS level (vfs layer) as the access pattern is sequential and predictable. We also save three syscalls (open, seek, close) for every chunk we send to the client (256kb).

[In the discussion](https://github.com/epoupon/lms/pull/683#issuecomment-2921939990) you mentioned the `sourceGood()` method and maybe throwing an exception instead directly in the constructor. I'm still not sure what the best approach to this would be. The advantage of not throwing an exception is that `processRequest()` will just send back a 404 in that case, so you don't need any extra logic at all the call sites to `createFileResourceHandler()` if you don't have any reason to do additional things if opening the file fails. Which seems to be most (all) call sites currently.

Another idea would be to either add a second constructor, or replace the current one, with one that takes a `std::ifstream`, so the caller can make any checks if they wish to, or if they don't, just pass an `ifstream` directly constructed as an argument.

Edits open :)