### PR TITLE
Return a 70 error code if the id's in subsonic scrobble are invalid

### DIFF
--- a/src/libs/subsonic/impl/endpoints/MediaAnnotation.cpp
+++ b/src/libs/subsonic/impl/endpoints/MediaAnnotation.cpp
@@ -176,6 +176,7 @@ namespace lms::api::subsonic
 
     Response handleScrobble(RequestContext& context)
     {
+        auto transaction{ context.getDbSession().createReadTransaction() };
         const std::vector<TrackId> ids{ getMandatoryMultiParametersAs<TrackId>(context.getParameters(), "id") };
         const std::vector<unsigned long> times{ getMultiParametersAs<unsigned long>(context.getParameters(), "time") };
         const bool submission{ getParameterAs<bool>(context.getParameters(), "submission").value_or(true) };
@@ -187,6 +188,13 @@ namespace lms::api::subsonic
         // if multiple submissions, must have all times
         if (ids.size() > 1 && ids.size() != times.size())
             throw BadParameterGenericError{ "time" };
+
+        for (std::size_t i{}; i < ids.size(); ++i)
+        {
+            const db::Track::pointer track{ db::Track::find(context.getDbSession(), ids[i]) };
+            if (!track)
+                throw RequestedDataNotFoundError{};
+        }
 
         if (!submission)
         {


### PR DESCRIPTION
This PR tries to implement the behaviour described in the OpenSubsonic discussion https://github.com/opensubsonic/open-subsonic-api/discussions/201

Maybe it is implemented in a bit of a naive way, specially creating the tack objects might not be necessary to check whether the track id is correct or not.

If any of the id's is invalid,  the answer now contains the error 70:

```
$ curl "https://example.org/rest/scrobble.view?id=tr-999999&id=tr-20000&time=1688760805000&time=1688760805000&submission=True&c=curl&v=1.16.0&f=json&u=user&p=enc:9999999999999999999999999999999999999999999999999999999999999"
{"subsonic-response":{"openSubsonic":true,"serverVersion":"v3.74.0","status":"failed","type":"lms","version":"1.16.1","error":{"code":70,"message":"The requested data was not found."}}}%
```