### PR TITLE
Feat/export m3u playlist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-<<<<<<< Updated upstream
-project(lms VERSION 3.72.1)
-=======
 project(lms VERSION 3.77.0)
->>>>>>> Stashed changes
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.12)
 
+<<<<<<< Updated upstream
 project(lms VERSION 3.72.1)
+=======
+project(lms VERSION 3.77.0)
+>>>>>>> Stashed changes
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules/)
 

--- a/approot/messages.xml
+++ b/approot/messages.xml
@@ -199,6 +199,7 @@
 <message id="Lms.Explore.bitrate">Bitrate</message>
 <message id="Lms.Explore.codec">Codec</message>
 <message id="Lms.Explore.download">Download</message>
+<message id="Lms.Explore.download-m3u">Download M3U</message>
 <message id="Lms.Explore.duration">Duration</message>
 <message id="Lms.Explore.filter-added">Filter added</message>
 <message id="Lms.Explore.filters">Filters</message>

--- a/approot/messages_es.xml
+++ b/approot/messages_es.xml
@@ -198,6 +198,7 @@
 <message id="Lms.Explore.bitrate">Bitrate</message>
 <message id="Lms.Explore.codec">Codec</message>
 <message id="Lms.Explore.download">Descargar</message>
+<message id="Lms.Explore.download-m3u">Descargar M3U</message>
 <message id="Lms.Explore.duration">Duración</message>
 <message id="Lms.Explore.filter-added">Filtro añadido</message>
 <message id="Lms.Explore.filters">Filtros</message>

--- a/approot/messages_fr.xml
+++ b/approot/messages_fr.xml
@@ -198,6 +198,7 @@
 <message id="Lms.Explore.bitrate">Bitrate</message>
 <message id="Lms.Explore.codec">Codec</message>
 <message id="Lms.Explore.download">Télécharger</message>
+<message id="Lms.Explore.download-m3u">Télécharger M3U</message>
 <message id="Lms.Explore.duration">Durée</message>
 <message id="Lms.Explore.filter-added">Filtre ajouté</message>
 <message id="Lms.Explore.filters">Filtres</message>

--- a/approot/tracklist.xml
+++ b/approot/tracklist.xml
@@ -14,6 +14,7 @@
 				<li>${play-shuffled class="dropdown-item"}</li>
 				<li>${play-last class="dropdown-item"}</li>
 				<li>${download class="dropdown-item"}</li>
+				<li>${download-m3u class="dropdown-item"}</li>
 				${<if-has-delete>}
 				<li>${delete class="dropdown-item"}</li>
 				${</if-has-delete>}

--- a/src/lms/CMakeLists.txt
+++ b/src/lms/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(lms
 	ui/resource/AudioTranscodingResource.cpp
 	ui/resource/ArtworkResource.cpp
 	ui/resource/DownloadResource.cpp
+	ui/resource/PlaylistExportResource.cpp
 	)
 
 target_include_directories(lms PRIVATE

--- a/src/lms/ui/explore/TrackListView.cpp
+++ b/src/lms/ui/explore/TrackListView.cpp
@@ -37,6 +37,7 @@
 #include "explore/PlayQueueController.hpp"
 #include "explore/TrackListHelpers.hpp"
 #include "resource/DownloadResource.hpp"
+#include "resource/PlaylistExportResource.hpp"
 
 namespace lms::ui
 {
@@ -137,6 +138,9 @@ namespace lms::ui
 
         bindNew<Wt::WPushButton>("download", Wt::WString::tr("Lms.Explore.download"))
             ->setLink(Wt::WLink{ std::make_unique<DownloadTrackListResource>(*trackListId) });
+
+        bindNew<Wt::WPushButton>("download-m3u", Wt::WString::tr("Lms.Explore.download-m3u"))
+            ->setLink(Wt::WLink{ std::make_unique<PlaylistExportResource>(*trackListId) });
 
         if (trackList->getUserId() == LmsApp->getUserId())
         {

--- a/src/lms/ui/resource/PlaylistExportResource.cpp
+++ b/src/lms/ui/resource/PlaylistExportResource.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Emeric Poupon
+ *
+ * This file is part of LMS.
+ *
+ * LMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * LMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PlaylistExportResource.hpp"
+
+#include <chrono>
+#include <Wt/Http/Response.h>
+#include <Wt/WDateTime.h>
+
+#include "database/Session.hpp"
+#include "database/objects/Track.hpp"
+#include "database/objects/TrackList.hpp"
+
+#include "LmsApplication.hpp"
+#include "core/String.hpp"
+
+namespace lms::ui
+{
+    PlaylistExportResource::PlaylistExportResource(db::TrackListId trackListId)
+        : _trackListId{ trackListId }
+    {
+        auto transaction{ LmsApp->getDbSession().createReadTransaction() };
+        const db::TrackList::pointer trackList{ db::TrackList::find(LmsApp->getDbSession(), trackListId) };
+        if (trackList)
+            suggestFileName(core::stringUtils::replaceInString(std::string{ trackList->getName() }, "/", "_") + ".m3u");
+    }
+
+    void PlaylistExportResource::handleRequest(const Wt::Http::Request& request, Wt::Http::Response& response)
+    {
+        auto transaction{ LmsApp->getDbSession().createReadTransaction() };
+
+        const db::TrackList::pointer trackList{ db::TrackList::find(LmsApp->getDbSession(), _trackListId) };
+        if (!trackList)
+        {
+            response.setStatus(404);
+            return;
+        }
+
+        response.setMimeType("audio/x-mpegurl");
+        
+        response.out() << "#EXTM3U\n";
+        
+        auto entries{ trackList->getEntries() };
+        for (const auto& entry : entries.results)
+        {
+            if (auto track{ entry->getTrack() })
+            {
+                long long durationSeconds = std::chrono::duration_cast<std::chrono::seconds>(track->getDuration()).count();
+                std::string artist{ track->getArtistDisplayName() };
+                std::string title = track->getName();
+
+                response.out() << "#EXTINF:" << durationSeconds << "," << artist << " - " << title << "\n";
+                response.out() << track->getAbsoluteFilePath().string() << "\n";
+            }
+        }
+    }
+} // namespace lms::ui

--- a/src/lms/ui/resource/PlaylistExportResource.hpp
+++ b/src/lms/ui/resource/PlaylistExportResource.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Emeric Poupon
+ *
+ * This file is part of LMS.
+ *
+ * LMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * LMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Wt/WResource.h>
+#include "database/objects/TrackListId.hpp"
+
+namespace lms::ui
+{
+    class PlaylistExportResource : public Wt::WResource
+    {
+    public:
+        PlaylistExportResource(db::TrackListId trackListId);
+
+    private:
+        void handleRequest(const Wt::Http::Request& request, Wt::Http::Response& response) override;
+        db::TrackListId _trackListId;
+    };
+} // namespace lms::ui


### PR DESCRIPTION
resolves #330 
Was able to compile and build a docker release image to test locally. 

<img width="235" height="317" alt="image" src="https://github.com/user-attachments/assets/55a800b5-abe3-4f40-82c0-1953e9b4c291" />

The first pass did a plain write, much like ones included in a album folder with just the file names with the full path -
```
/music/Eddy.Kenny/eddyizm_kenny_project2.mp3
/music/eddyizm 2013/STE-005-edit.mp3
/music/10_be_strong_chosen few children may 2005.mp3
/music/Those Guys/09 Track 9.mp3
/music/eddyizm 2013/Live_at_Glenns.mp3
```

i then tried to update it to what seemed like a more standard format. 

the m3u format looks ok however it is pointing to the volume path of the container
```
#EXTM3U
#EXTINF:282,axume - project 2
/music/Eddy.Kenny/eddyizm_kenny_project2.mp3
#EXTINF:3411, - STE-005-edit.mp3
/music/eddyizm 2013/STE-005-edit.mp3
#EXTINF:270,10 - be_strong_chosen few children
/music/10_be_strong_chosen few children may 2005.mp3
#EXTINF:103,Those Guys - Track 9
/music/Those Guys/09 Track 9.mp3
#EXTINF:10590, - Live_at_Glenns.mp3
/music/eddyizm 2013/Live_at_Glenns.mp3
```
Not sure which one is preferred. 